### PR TITLE
書籍に合わせて表記を統一(10章,11章)

### DIFF
--- a/ch10_dash_cytoscape_basic/basic/hello_dash_cyto.py
+++ b/ch10_dash_cytoscape_basic/basic/hello_dash_cyto.py
@@ -32,5 +32,5 @@ cyto_compo = cyto.Cytoscape(
 app.layout = html.Div([cyto_compo])
 
 if __name__ == "__main__":
-    # サーバーの起動
+    # サーバの起動
     app.run_server(debug=True)

--- a/ch10_dash_cytoscape_basic/elements/basic_elements_additional_key.py
+++ b/ch10_dash_cytoscape_basic/elements/basic_elements_additional_key.py
@@ -67,5 +67,5 @@ cyto_compo = cyto.Cytoscape(
 app.layout = html.Div([cyto_compo])
 
 if __name__ == "__main__":
-    # サーバーの起動
+    # サーバの起動
     app.run_server(debug=True)

--- a/ch10_dash_cytoscape_basic/elements/basic_elements_interactive.py
+++ b/ch10_dash_cytoscape_basic/elements/basic_elements_interactive.py
@@ -52,5 +52,5 @@ cyto_compo = cyto.Cytoscape(
 app.layout = html.Div([cyto_compo])
 
 if __name__ == "__main__":
-    # サーバーの起動
+    # サーバの起動
     app.run_server(debug=True)

--- a/ch10_dash_cytoscape_basic/elements/basic_elements_label.py
+++ b/ch10_dash_cytoscape_basic/elements/basic_elements_label.py
@@ -32,5 +32,5 @@ cyto_compo = cyto.Cytoscape(
 app.layout = html.Div([cyto_compo])
 
 if __name__ == "__main__":
-    # サーバーの起動
+    # サーバの起動
     app.run_server(debug=True)

--- a/ch10_dash_cytoscape_basic/style/dash_cyto_style_label.py
+++ b/ch10_dash_cytoscape_basic/style/dash_cyto_style_label.py
@@ -45,5 +45,5 @@ cyto_compo = cyto.Cytoscape(
 app.layout = html.Div([cyto_compo])
 
 if __name__ == "__main__":
-    # サーバーの起動
+    # サーバの起動
     app.run_server(debug=True)

--- a/ch11_dash_cytoscape_advance/callback/callback_elements_remove.py
+++ b/ch11_dash_cytoscape_advance/callback/callback_elements_remove.py
@@ -7,7 +7,7 @@ from dash.dependencies import Input, Output, State
 app = dash.Dash(__name__)
 
 # ノードを10個定義
-default_nodes = [{"data": {"id": x}} for x in range(0, 10)]
+default_nodes = [{"data": {"id": x}} for x in range(10)]
 
 # エッジを定義 (木構造)
 default_edges = [

--- a/ch11_dash_cytoscape_advance/callback/callback_elements_selected.py
+++ b/ch11_dash_cytoscape_advance/callback/callback_elements_selected.py
@@ -7,7 +7,7 @@ from dash.dependencies import Input, Output
 app = dash.Dash(__name__)
 
 # ノードを10個定義
-default_nodes = [{"data": {"id": x}} for x in range(0, 10)]
+default_nodes = [{"data": {"id": x}} for x in range(10)]
 
 # エッジを定義 (木構造)
 default_edges = [

--- a/ch11_dash_cytoscape_advance/callback/callback_layout.py
+++ b/ch11_dash_cytoscape_advance/callback/callback_layout.py
@@ -7,7 +7,7 @@ from dash.dependencies import Input, Output
 app = dash.Dash(__name__)
 
 # ノードを10個定義
-default_nodes = [{"data": {"id": x}} for x in range(0, 10)]
+default_nodes = [{"data": {"id": x}} for x in range(10)]
 
 # エッジを定義 (木構造)
 default_edges = [

--- a/ch11_dash_cytoscape_advance/callback/callback_style.py
+++ b/ch11_dash_cytoscape_advance/callback/callback_style.py
@@ -7,7 +7,7 @@ from dash.dependencies import Input, Output
 app = dash.Dash(__name__)
 
 # ノードを10個定義
-default_nodes = [{"data": {"id": x}} for x in range(0, 10)]
+default_nodes = [{"data": {"id": x}} for x in range(10)]
 
 # エッジを定義 (木構造)
 default_edges = [

--- a/ch11_dash_cytoscape_advance/callback/event_callback_neighbor_nodes.py
+++ b/ch11_dash_cytoscape_advance/callback/event_callback_neighbor_nodes.py
@@ -91,5 +91,5 @@ def change_neighbor_node_style(node_element_dict):
 
 
 if __name__ == "__main__":
-    # サーバーの起動
+    # サーバの起動
     app.run_server(debug=True)

--- a/ch11_dash_cytoscape_advance/callback/event_callback_tapnode.py
+++ b/ch11_dash_cytoscape_advance/callback/event_callback_tapnode.py
@@ -63,5 +63,5 @@ def show_tapped_node(node_element_dict):
 
 
 if __name__ == "__main__":
-    # サーバーの起動
+    # サーバの起動
     app.run_server(debug=True)

--- a/ch11_dash_cytoscape_advance/callback/event_callback_tapnode_data.py
+++ b/ch11_dash_cytoscape_advance/callback/event_callback_tapnode_data.py
@@ -63,5 +63,5 @@ def show_tapped_node_data(node_data_dict):
 
 
 if __name__ == "__main__":
-    # サーバーの起動
+    # サーバの起動
     app.run_server(debug=True)


### PR DESCRIPTION
- `range` の書き方を統一
- `サーバー` -> `サーバ` に統一